### PR TITLE
Don't show image alt text as caption

### DIFF
--- a/src/imageFigurePlugin.ts
+++ b/src/imageFigurePlugin.ts
@@ -3,7 +3,7 @@ import type MarkdownIt from 'markdown-it';
 
 function getCaption(image: MarkdownIt.Token): string {
 	const title = image.attrGet('title');
-	return title ?? image.content;
+	return title ?? '';
 }
 
 const figure: MarkdownIt.Core.RuleCore = (state) => {


### PR DESCRIPTION
Noticed when looking at a tournament banner in preview and web. Fallback to an empty string instead.